### PR TITLE
Add option to exclude individual tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 
 script:
   - mvn install -B
-  - ./tempto-examples/bin/run_on_docker.sh --thread-count 2 -x failing
+  - ./tempto-examples/bin/run_on_docker.sh --thread-count 2 -x failing -e io.prestosql.tempto.examples.ExclusionTest.failingTest
   - CONFIG_FILE=tempto-configuration-read-only.yaml ./tempto-examples/bin/run_on_docker.sh --thread-count 2 -g in_memory
   - CONFIG_FILE=tempto-configuration-no-db.yaml ./tempto-examples/bin/run_on_docker.sh --thread-count 2 -g ssh
   - CONFIG_FILE=tempto-configuration-invalid-ssh-and-psql.yaml ./tempto-examples/bin/run_on_docker.sh --thread-count 2 -g in_memory

--- a/tempto-core/src/test/groovy/io/prestosql/tempto/runner/TestNameGroupNameMethodSelectorTest.groovy
+++ b/tempto-core/src/test/groovy/io/prestosql/tempto/runner/TestNameGroupNameMethodSelectorTest.groovy
@@ -32,10 +32,11 @@ class TestNameGroupNameMethodSelectorTest
     {
         setup:
         metadataReader.readTestMetadata(_) >> new TestMetadata(testGroups as Set, testName)
-        def testSelector = new TestNameGroupNameMethodSelector(asSetOptional(allowedTestNames),
+        def testSelector = new TestNameGroupNameMethodSelector(
+                asSetOptional(allowedTestNames),
                 asSetOptional(allowedTestGroups),
-                asSetOptional(excludedTestGroups),
-                metadataReader);
+                asSet(excludedTestGroups),
+                metadataReader)
 
         expect:
         testSelector.includeMethod(Mock(IMethodSelectorContext), Mock(ITestNGMethod), true) == expected
@@ -65,6 +66,16 @@ class TestNameGroupNameMethodSelectorTest
         }
         else {
             return Optional.of(strings as Set);
+        }
+    }
+
+    private static Set<String> asSet(List<String> strings)
+    {
+        if (strings == null) {
+            return []
+        }
+        else {
+            return strings as Set
         }
     }
 }

--- a/tempto-core/src/test/groovy/io/prestosql/tempto/runner/TestNameGroupNameMethodSelectorTest.groovy
+++ b/tempto-core/src/test/groovy/io/prestosql/tempto/runner/TestNameGroupNameMethodSelectorTest.groovy
@@ -34,6 +34,7 @@ class TestNameGroupNameMethodSelectorTest
         metadataReader.readTestMetadata(_) >> new TestMetadata(testGroups as Set, testName)
         def testSelector = new TestNameGroupNameMethodSelector(
                 asSetOptional(allowedTestNames),
+                asSet(excludedTestNames),
                 asSetOptional(allowedTestGroups),
                 asSet(excludedTestGroups),
                 metadataReader)
@@ -42,21 +43,27 @@ class TestNameGroupNameMethodSelectorTest
         testSelector.includeMethod(Mock(IMethodSelectorContext), Mock(ITestNGMethod), true) == expected
 
         where:
-        testName    | testGroups   | allowedTestNames | allowedTestGroups | excludedTestGroups | expected
-        'abc'       | ['g1', 'g2'] | null             | null              | null               | true
-        'abc'       | ['g1', 'g2'] | ['abc']          | null              | null               | true
-        'abc'       | ['g1', 'g2'] | ['xyz', 'abc']   | null              | null               | true
-        'abc'       | ['g1', 'g2'] | null             | ['g1']            | null               | true
-        'abc'       | ['g1', 'g2'] | null             | ['g1', 'g3']      | null               | true
-        'abc'       | ['g1', 'g2'] | ['xyz', 'abc']   | ['g1', 'g3']      | null               | true
-        'p.q.r.abc' | []           | ['abc']          | null              | null               | true
-        'p.q.r.abc' | []           | ['r.abc']        | null              | null               | true
-        'p.q.r.abc' | []           | ['p.q.r.abc']    | null              | null               | true
-        'p.q.r.abc' | []           | ['bc']           | null              | null               | true
-        'p.q.r.abc' | []           | ['xbc']          | null              | null               | false
-        'abc'       | ['g1', 'g2'] | ['xyz', 'abc']   | ['g1', 'g3']      | ['g1']             | false
-        'abc'       | ['g1', 'g2'] | ['xyz', 'abc']   | ['g1', 'g3']      | ['g2']             | false
-        'abc'       | ['g1', 'g2'] | ['xyz', 'abc']   | ['g1', 'g3']      | ['g5']             | true
+        testName    | testGroups   | allowedTestNames | excludedTestNames | allowedTestGroups | excludedTestGroups | expected
+        'abc'       | ['g1', 'g2'] | null             | null              | null              | null               | true
+        'abc'       | ['g1', 'g2'] | ['abc']          | null              | null              | null               | true
+        'abc'       | ['g1', 'g2'] | ['xyz', 'abc']   | null              | null              | null               | true
+        'abc'       | ['g1', 'g2'] | null             | null              | ['g1']            | null               | true
+        'abc'       | ['g1', 'g2'] | null             | null              | ['g1', 'g3']      | null               | true
+        'abc'       | ['g1', 'g2'] | ['xyz', 'abc']   | null              | ['g1', 'g3']      | null               | true
+        'p.q.r.abc' | []           | ['abc']          | null              | null              | null               | true
+        'p.q.r.abc' | []           | ['r.abc']        | null              | null              | null               | true
+        'p.q.r.abc' | []           | ['p.q.r.abc']    | null              | null              | null               | true
+        'p.q.r.abc' | []           | ['bc']           | null              | null              | null               | true
+        'p.q.r.abc' | []           | ['xbc']          | null              | null              | null               | false
+        'abc'       | ['g1', 'g2'] | ['xyz', 'abc']   | null              | ['g1', 'g3']      | ['g1']             | false
+        'abc'       | ['g1', 'g2'] | ['xyz', 'abc']   | null              | ['g1', 'g3']      | ['g2']             | false
+        'abc'       | ['g1', 'g2'] | ['xyz', 'abc']   | ['qwe']           | ['g1', 'g3']      | ['g5']             | true
+        'abc'       | ['g1', 'g2'] | ['xyz', 'abc']   | ['ab']            | ['g1', 'g3']      | ['g5']             | true
+        'abc'       | ['g1', 'g2'] | null             | ['abc']           | ['g1', 'g3']      | ['g5']             | false
+        'abc'       | ['g1', 'g2'] | ['xyz', 'abc']   | ['abc']           | ['g1', 'g3']      | ['g5']             | false
+        'p.q.r.abc' | ['g1', 'g2'] | null             | ['p.q.r.xyz']     | ['g1', 'g3']      | ['g5']             | true
+        'p.q.r.abc' | ['g1', 'g2'] | null             | ['p.q.r.ab']      | ['g1', 'g3']      | ['g5']             | true
+        'p.q.r.abc' | ['g1', 'g2'] | null             | ['p.q.r.abc']     | ['g1', 'g3']      | ['g5']             | false
     }
 
     private Optional<Set<String>> asSetOptional(List<String> strings)

--- a/tempto-examples/src/main/java/io/prestosql/tempto/examples/ExclusionTest.java
+++ b/tempto-examples/src/main/java/io/prestosql/tempto/examples/ExclusionTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.prestosql.tempto.examples;
+
+import org.testng.annotations.Test;
+
+import static org.testng.FileAssert.fail;
+
+public class ExclusionTest
+{
+    @Test
+    public void passingTest()
+    {
+    }
+
+    @Test
+    public void failingTest()
+    {
+        fail("Method failingTest() should have been excluded from the execution");
+    }
+}

--- a/tempto-runner/src/main/java/io/prestosql/tempto/runner/TemptoRunner.java
+++ b/tempto-runner/src/main/java/io/prestosql/tempto/runner/TemptoRunner.java
@@ -33,6 +33,7 @@ import static io.prestosql.tempto.internal.convention.ConventionTestsUtils.CONVE
 import static io.prestosql.tempto.internal.convention.ConventionTestsUtils.CONVENTION_TESTS_RESULTS_DUMP_PATH_KEY;
 import static io.prestosql.tempto.internal.listeners.TestNameGroupNameMethodSelector.TEST_GROUPS_TO_EXCLUDE_PROPERTY;
 import static io.prestosql.tempto.internal.listeners.TestNameGroupNameMethodSelector.TEST_GROUPS_TO_RUN_PROPERTY;
+import static io.prestosql.tempto.internal.listeners.TestNameGroupNameMethodSelector.TEST_NAMES_TO_EXCLUDE_PROPERTY;
 import static io.prestosql.tempto.internal.listeners.TestNameGroupNameMethodSelector.TEST_NAMES_TO_RUN_PROPERTY;
 import static java.util.Collections.singletonList;
 
@@ -108,6 +109,9 @@ public class TemptoRunner
         }
         if (!options.getTests().isEmpty()) {
             System.setProperty(TEST_NAMES_TO_RUN_PROPERTY, Joiner.on(',').join(options.getTests()));
+        }
+        if (!options.getExcludedTests().isEmpty()) {
+            System.setProperty(TEST_NAMES_TO_EXCLUDE_PROPERTY, Joiner.on(',').join(options.getExcludedTests()));
         }
         testNG.addMethodSelector(METHOD_SELECTOR_CLASS_NAME, METHOD_SELECTOR_PRIORITY);
     }

--- a/tempto-runner/src/main/java/io/prestosql/tempto/runner/TemptoRunnerCommandLineParser.java
+++ b/tempto-runner/src/main/java/io/prestosql/tempto/runner/TemptoRunnerCommandLineParser.java
@@ -40,6 +40,7 @@ import static io.prestosql.tempto.runner.TemptoRunnerOptions.CONFIG_FILES;
 import static io.prestosql.tempto.runner.TemptoRunnerOptions.CONVENTION_TESTS_DIR;
 import static io.prestosql.tempto.runner.TemptoRunnerOptions.DUMP_CONVENTION_RESULTS;
 import static io.prestosql.tempto.runner.TemptoRunnerOptions.EXCLUDED_GROUPS;
+import static io.prestosql.tempto.runner.TemptoRunnerOptions.EXCLUDED_TESTS;
 import static io.prestosql.tempto.runner.TemptoRunnerOptions.GROUPS;
 import static io.prestosql.tempto.runner.TemptoRunnerOptions.HELP;
 import static io.prestosql.tempto.runner.TemptoRunnerOptions.PACKAGE;
@@ -180,6 +181,7 @@ public class TemptoRunnerCommandLineParser
             addOption(PACKAGE);
             addOption(REPORT_DIR);
             addOption(TESTS);
+            addOption(EXCLUDED_TESTS);
             addOption(HELP);
             addOption(DUMP_CONVENTION_RESULTS);
             addOption(THREAD_COUNT);

--- a/tempto-runner/src/main/java/io/prestosql/tempto/runner/TemptoRunnerOptions.java
+++ b/tempto-runner/src/main/java/io/prestosql/tempto/runner/TemptoRunnerOptions.java
@@ -76,6 +76,13 @@ public class TemptoRunnerOptions
             .hasArg()
             .build();
 
+    public static final Option EXCLUDED_TESTS = Option.builder("e")
+            .longOpt("excluded-tests")
+            .desc("Test name suffix to be excluded")
+            .valueSeparator(',')
+            .hasArg()
+            .build();
+
     public static final Option HELP = Option.builder("h")
             .longOpt("help")
             .build();
@@ -133,6 +140,11 @@ public class TemptoRunnerOptions
     public Set<String> getTests()
     {
         return getValues(TESTS.getLongOpt());
+    }
+
+    public Set<String> getExcludedTests()
+    {
+        return getValues(EXCLUDED_TESTS.getLongOpt());
     }
 
     public boolean isHelpRequested()


### PR DESCRIPTION
Passing arguments `-e MyTest.myTestMethod` will cause myTestMethod()
to be excluded from execution (similar to -x for groups)