### PR TITLE
Always log test name on status line

### DIFF
--- a/tempto-core/src/main/java/io/prestosql/tempto/internal/listeners/ProgressLoggingListener.java
+++ b/tempto-core/src/main/java/io/prestosql/tempto/internal/listeners/ProgressLoggingListener.java
@@ -91,12 +91,7 @@ public class ProgressLoggingListener
     private void logTestEnd(ITestResult testCase, String outcome)
     {
         long executionTime = currentTimeMillis() - testStartTime;
-        if (executionTime < 1000) {
-            LOGGER.info(outcome);
-        }
-        else {
-            LOGGER.info("{}     /    {} took {}", outcome, formatTestName(testCase), formatDuration(executionTime));
-        }
+        LOGGER.info("{}     /    {} took {}", outcome, formatTestName(testCase), formatDuration(executionTime));
     }
 
     @Override


### PR DESCRIPTION
This is useful when grepping test logs for FAILURE or SUCCESS entries.