### PR TITLE
Use kafka-clients 2.4 for creating and deleting topics

### DIFF
--- a/tempto-kafka/pom.xml
+++ b/tempto-kafka/pom.xml
@@ -39,19 +39,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>1.1.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.12</artifactId>
-            <version>1.1.1</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.101tec</groupId>
-            <artifactId>zkclient</artifactId>
-            <version>0.10</version>
+            <version>2.4.1</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
We have two different, conflicting kafka-clients versions on the presto-product-tests classpath. This PR removed old client and uses newer instead. 