### PR TITLE
Add JAVA_OBJECT type to query result comparator

### DIFF
--- a/tempto-core/src/main/java/io/prestosql/tempto/assertions/QueryResultValueComparator.java
+++ b/tempto-core/src/main/java/io/prestosql/tempto/assertions/QueryResultValueComparator.java
@@ -104,6 +104,8 @@ class QueryResultValueComparator
                 return timestampWithTimezoneEqual(actual, expected);
             case ARRAY:
                 return arrayEqual(actual, expected);
+            case JAVA_OBJECT:
+                return javaObjectEqual(actual, expected);
             default:
                 throw new RuntimeException("Unsupported sql type " + type);
         }
@@ -259,6 +261,11 @@ class QueryResultValueComparator
             return actual.equals(expected);
         }
         return false;
+    }
+
+    private boolean javaObjectEqual(Object actual, Object expected)
+    {
+        return actual.equals(expected);
     }
 
     private static boolean isLongOrNarrower(Object value)

--- a/tempto-core/src/test/groovy/io/prestosql/tempto/assertions/QueryResultValueComparatorTest.groovy
+++ b/tempto-core/src/test/groovy/io/prestosql/tempto/assertions/QueryResultValueComparatorTest.groovy
@@ -32,6 +32,7 @@ import static java.sql.JDBCType.DECIMAL
 import static java.sql.JDBCType.DOUBLE
 import static java.sql.JDBCType.FLOAT
 import static java.sql.JDBCType.INTEGER
+import static java.sql.JDBCType.JAVA_OBJECT
 import static java.sql.JDBCType.LONGVARBINARY
 import static java.sql.JDBCType.LONGVARCHAR
 import static java.sql.JDBCType.NUMERIC
@@ -129,6 +130,13 @@ class QueryResultValueComparatorTest
         TIMESTAMP               | Timestamp.valueOf("2015-02-16 10:10:10") | Timestamp.valueOf("2015-02-15 10:10:10") | false
         TIMESTAMP               | Timestamp.valueOf("2015-02-15 10:10:10") | Timestamp.valueOf("2015-02-16 10:10:10") | false
         TIMESTAMP               | Timestamp.valueOf("2015-02-15 10:10:10") | "a"                                      | false
+
+        JAVA_OBJECT             | null                                     | null                                     | true
+        JAVA_OBJECT             | UUID.fromString("50554d6e-29bb-11e5-b345-feff819cdc9f") | UUID.fromString("50554d6e-29bb-11e5-b345-feff819cdc9f") | true
+        JAVA_OBJECT             | UUID.fromString("12151fd2-7586-11e9-8f9e-2a86e4085a59") | UUID.fromString("12151fd2-7586-11e9-8f9e-2a86e4085a59") | true
+        JAVA_OBJECT             | UUID.fromString("50554d6e-29bb-11e5-b345-feff819cdc9f") | UUID.fromString("12151fd2-7586-11e9-8f9e-2a86e4085a59") | false
+        JAVA_OBJECT             | UUID.fromString("50554d6e-29bb-11e5-b345-feff819cdc9f") | "50554d6e-29bb-11e5-b345-feff819cdc9f" | false
+        JAVA_OBJECT             | UUID.fromString("50554d6e-29bb-11e5-b345-feff819cdc9f") | "a"                       | false
     }
 
     @Unroll


### PR DESCRIPTION
To support UUID type in https://github.com/prestosql/presto/pull/5231