### PR TITLE
Log test method parameters

### DIFF
--- a/tempto-core/src/main/java/io/prestosql/tempto/internal/listeners/ProgressLoggingListener.java
+++ b/tempto-core/src/main/java/io/prestosql/tempto/internal/listeners/ProgressLoggingListener.java
@@ -113,7 +113,18 @@ public class ProgressLoggingListener
     {
         TestMetadata testMetadata = testMetadataReader.readTestMetadata(testCase);
         String testGroups = Joiner.on(", ").join(testMetadata.testGroups);
-        return format("%s (Groups: %s)", testMetadata.testName, testGroups);
+        String testParameters = formatTestParameters(testMetadata.testParameters);
+
+        return format("%s%s (Groups: %s)", testMetadata.testName, testParameters, testGroups);
+    }
+
+    private String formatTestParameters(Object[] testParameters)
+    {
+        if (testParameters.length == 0) {
+            return "";
+        }
+
+        return format(" [%s]", Joiner.on(", ").join(testParameters));
     }
 
     private static String formatDuration(long durationInMillis)

--- a/tempto-core/src/main/java/io/prestosql/tempto/internal/listeners/TestMetadata.java
+++ b/tempto-core/src/main/java/io/prestosql/tempto/internal/listeners/TestMetadata.java
@@ -16,6 +16,7 @@ package io.prestosql.tempto.internal.listeners;
 
 import java.util.Set;
 
+import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.collect.ImmutableSet.copyOf;
 
@@ -23,10 +24,12 @@ public class TestMetadata
 {
     public final Set<String> testGroups;
     public final String testName;
+    public final Object[] testParameters;
 
-    public TestMetadata(Set<String> testGroups, String testName)
+    public TestMetadata(Set<String> testGroups, String testName, Object[] testParameters)
     {
         this.testGroups = copyOf(checkNotNull(testGroups, "testGroups can not be null"));
         this.testName = checkNotNull(testName, "testName can not be null");
+        this.testParameters = firstNonNull(testParameters, new Object[]{});
     }
 }

--- a/tempto-core/src/main/java/io/prestosql/tempto/internal/listeners/TestMetadataReader.java
+++ b/tempto-core/src/main/java/io/prestosql/tempto/internal/listeners/TestMetadataReader.java
@@ -19,6 +19,7 @@ import io.prestosql.tempto.testmarkers.WithTestGroups;
 import org.testng.ITestNGMethod;
 import org.testng.ITestResult;
 
+import java.util.Map;
 import java.util.Set;
 
 import static com.google.common.collect.Sets.newHashSet;
@@ -28,14 +29,23 @@ public class TestMetadataReader
 {
     public TestMetadata readTestMetadata(ITestResult testResult)
     {
-        return readTestMetadata(testResult.getMethod());
+        return new TestMetadata(
+                readTestGroups(testResult.getMethod()),
+                readTestName(testResult.getMethod()),
+                readTestParameters(testResult));
     }
 
     public TestMetadata readTestMetadata(ITestNGMethod testMethod)
     {
         return new TestMetadata(
                 readTestGroups(testMethod),
-                readTestName(testMethod));
+                readTestName(testMethod),
+                null);
+    }
+
+    private Object[] readTestParameters(ITestResult testResult)
+    {
+        return testResult.getParameters();
     }
 
     private Set<String> readTestGroups(ITestNGMethod method)


### PR DESCRIPTION
Fixes https://github.com/prestosql/tempto/issues/19
Fixes https://github.com/prestosql/presto/issues/1759

Looks like this:

```
tests               | 2020-09-25 16:24:28 INFO: [1 of 1] io.prestosql.tests.hive.TestHiveStorageFormats.testTimestamp [StorageFormat{name=ORC, properties={}, sessionProperties={hive.orc_optimized_writer_validate=true}}] (Groups: storage_formats)
```