### PR TITLE
Include SQL query when execution fails

### DIFF
--- a/tempto-core/src/main/java/io/prestosql/tempto/query/JdbcQueryExecutor.java
+++ b/tempto-core/src/main/java/io/prestosql/tempto/query/JdbcQueryExecutor.java
@@ -118,6 +118,7 @@ public class JdbcQueryExecutor
     private QueryResult executeQueryNoParams(String sql)
             throws SQLException
     {
+        requireNonNull(sql, "sql is null");
         try (Statement statement = getConnection().createStatement()) {
             if (statement.execute(sql)) {
                 return QueryResult.forResultSet(statement.getResultSet());
@@ -126,12 +127,18 @@ public class JdbcQueryExecutor
                 return forSingleIntegerValue(statement.getUpdateCount());
             }
         }
+        catch (Throwable e) {
+            e.addSuppressed(new Exception("Query: " + sql));
+            throw e;
+        }
     }
 
     // TODO - remove this method as soon as Presto supports prepared statements
     private QueryResult executeQueryWithParams(String sql, QueryParam[] params)
             throws SQLException
     {
+        requireNonNull(sql, "sql is null");
+        requireNonNull(params, "params is null");
         try (PreparedStatement statement = getConnection().prepareStatement(sql)) {
             setQueryParams(statement, params);
 
@@ -141,6 +148,10 @@ public class JdbcQueryExecutor
             else {
                 return forSingleIntegerValue(statement.getUpdateCount());
             }
+        }
+        catch (Throwable e) {
+            e.addSuppressed(new Exception("Query: " + sql));
+            throw e;
         }
     }
 


### PR DESCRIPTION
In Presto we sometimes observe failures like

```
io.prestosql.tempto.query.QueryExecutionException: java.sql.SQLException: Error while compiling statement: FAILED: ParseException line 1:79 Failed to recognize predicate '<EOF>'. Failed rule: 'regularBody' in statement
	at io.prestosql.tempto.query.JdbcQueryExecutor.execute(JdbcQueryExecutor.java:114)
	at io.prestosql.tempto.query.JdbcQueryExecutor.executeQuery(JdbcQueryExecutor.java:82)
	at io.prestosql.tests.hive.TestHiveBucketedTables.populateRowToHiveTable(TestHiveBucketedTables.java:327)
	at io.prestosql.tests.hive.TestHiveBucketedTables.testSelectFromIncompleteBucketedTableEmptyTablesAllowed(TestHiveBucketedTables.java:206)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:104)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:645)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:851)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1177)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:129)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:112)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.sql.SQLException: Error while compiling statement: FAILED: ParseException line 1:79 Failed to recognize predicate '<EOF>'. Failed rule: 'regularBody' in statement
	at org.apache.hive.jdbc.Utils.verifySuccess(Utils.java:121)
	at org.apache.hive.jdbc.Utils.verifySuccessWithInfo(Utils.java:109)
	at org.apache.hive.jdbc.HiveStatement.execute(HiveStatement.java:231)
	at io.prestosql.tempto.query.JdbcQueryExecutor.executeQueryNoParams(JdbcQueryExecutor.java:122)
	at io.prestosql.tempto.query.JdbcQueryExecutor.execute(JdbcQueryExecutor.java:107)
	... 16 more
```

While the query is logged (at DEBUG) prior to being executed, it is
convenient to know failing query's text even if DEBUG logging is not
enabled.