### PR TITLE
Remove java.sql.SQLException from failsWithMessageMatching expected messages

### DIFF
--- a/tempto-core/src/main/java/io/trino/tempto/query/QueryExecutionException.java
+++ b/tempto-core/src/main/java/io/trino/tempto/query/QueryExecutionException.java
@@ -19,6 +19,6 @@ public class QueryExecutionException
 {
     public QueryExecutionException(Throwable e)
     {
-        super(e);
+        super(e.getMessage(), e);
     }
 }

--- a/tempto-core/src/test/groovy/io/trino/tempto/assertions/QueryAssertTest.groovy
+++ b/tempto-core/src/test/groovy/io/trino/tempto/assertions/QueryAssertTest.groovy
@@ -496,17 +496,26 @@ B|ARGENTINA|SOUTH AMERICA|>'''
 
         then:
         def e = thrown(AssertionError)
-        e.message == "Query failed with unexpected error message: 'java.lang.RuntimeException: foo bar' \n" +
+        e.message == "Query failed with unexpected error message: 'foo bar' \n" +
                 " Expected error message to contain 'dummy'"
         def suppressed = e.getSuppressed()[0]
         suppressed.class == QueryExecutionException.class
-        suppressed.message == "java.lang.RuntimeException: foo bar"
+        suppressed.message == "foo bar"
     }
 
     def 'QueryExecutionAssert - right error message'()
     {
         when:
         assertThat({ throw new QueryExecutionException(new RuntimeException("dummy")) }).failsWithMessage("dummy")
+
+        then:
+        noExceptionThrown()
+    }
+
+    def 'QueryExecutionAssert - null error message'()
+    {
+        when:
+        assertThat({ throw new QueryExecutionException(new RuntimeException()) }).failsWithMessage("") // null message is coalesced into empty
 
         then:
         noExceptionThrown()
@@ -519,17 +528,17 @@ B|ARGENTINA|SOUTH AMERICA|>'''
 
         then:
         def e = thrown(AssertionError)
-        e.message == "Query failed with unexpected error message: 'java.lang.RuntimeException: foo bar' \n" +
+        e.message == "Query failed with unexpected error message: 'foo bar' \n" +
                 " Expected error message to match 'foo'"
         def suppressed = e.getSuppressed()[0]
         suppressed.class == QueryExecutionException.class
-        suppressed.message == "java.lang.RuntimeException: foo bar"
+        suppressed.message == "foo bar"
     }
 
     def 'QueryExecutionAssert - error message matches'()
     {
         when:
-        assertThat({ throw new QueryExecutionException(new RuntimeException("dummy")) }).failsWithMessageMatching("^java.lang.RuntimeException: dug?(m){2,4}y\$")
+        assertThat({ throw new QueryExecutionException(new RuntimeException("dummy")) }).failsWithMessageMatching("^dug?(m){2,4}y\$")
 
         then:
         noExceptionThrown()


### PR DESCRIPTION
Previously the SQLException's class name was prepended to captured
exception's message and would be required in `failsWithMessageMatching`
for full match.

Note that `failsWithMessage` is generally not affected since it does
substring matching (unless someone was expecting exception class name in
the message).