### PR TITLE
Switch over to AssertJ for query exceptional assertions

### DIFF
--- a/tempto-core/src/main/java/io/trino/tempto/assertions/QueryAssert.java
+++ b/tempto-core/src/main/java/io/trino/tempto/assertions/QueryAssert.java
@@ -22,6 +22,7 @@ import io.trino.tempto.query.QueryExecutionException;
 import io.trino.tempto.query.QueryExecutor;
 import io.trino.tempto.query.QueryResult;
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.Assertions;
 import org.intellij.lang.annotations.Language;
 import org.slf4j.Logger;
@@ -76,6 +77,10 @@ public class QueryAssert
         return new QueryAssert(queryResult);
     }
 
+    /**
+     * @deprecated Use {@link #assertQueryFailure(QueryCallback)} instead.
+     */
+    @Deprecated
     @CheckReturnValue
     public static QueryExecutionAssert assertThat(QueryCallback queryCallback)
     {
@@ -87,6 +92,19 @@ public class QueryAssert
             executionException = e;
         }
         return new QueryExecutionAssert(ofNullable(executionException));
+    }
+
+    @CheckReturnValue
+    public static AbstractThrowableAssert<?, ? extends Throwable> assertQueryFailure(QueryCallback queryCallback)
+    {
+        QueryExecutionException executionException = null;
+        try {
+            queryCallback.executeQuery();
+        }
+        catch (QueryExecutionException e) {
+            return Assertions.assertThat(e.getCause());
+        }
+        throw new AssertionError("Expected callback to throw QueryExecutionException");
     }
 
     public QueryAssert matches(SqlResultDescriptor sqlResultDescriptor)
@@ -422,6 +440,7 @@ public class QueryAssert
                 throws QueryExecutionException;
     }
 
+    @Deprecated
     public static class QueryExecutionAssert
     {
         private Optional<QueryExecutionException> executionExceptionOptional;


### PR DESCRIPTION
`QueryAssert.assertThat(callback)` has three problems:

- `failsWithMessage` does substring matching, despite its name
- `failsWithMessageMatching` is matched against original exception `toString()`
  (including e.g. "java.sql.SQLException: " prefix)
- it's redundant over AssertJ, so fixing these problems seems like waste of
  time.


cc @kokosing 