### PR TITLE
Allow After/BeforeTestWithContext usage in superclass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     - name: test
       run: ./mvnw install -B
     - name: tempto test (exclusion)
-      run: ./tempto-examples/bin/run_on_docker.sh --thread-count 2 -x failing -e io.prestosql.tempto.examples.ExclusionTest.failingTest,io.prestosql.tempto.examples.AnotherExclusionTest
+      run: ./tempto-examples/bin/run_on_docker.sh --thread-count 2 -x failing -e io.trino.tempto.examples.ExclusionTest.failingTest,io.trino.tempto.examples.AnotherExclusionTest
     - name: tempto test (config-read-only)
       run: CONFIG_FILE=tempto-configuration-read-only.yaml ./tempto-examples/bin/run_on_docker.sh --thread-count 2 -g in_memory
     - name: tempto test (config-no-db)

--- a/tempto-core/src/main/java/io/trino/tempto/internal/initialization/TestInitializationListener.java
+++ b/tempto-core/src/main/java/io/trino/tempto/internal/initialization/TestInitializationListener.java
@@ -256,7 +256,7 @@ public class TestInitializationListener
 
     private void invokeMethodsAnnotatedWith(Class<? extends Annotation> annotationClass, ITestResult testCase, TestContext testContext)
     {
-        for (Method declaredMethod : testCase.getTestClass().getRealClass().getDeclaredMethods()) {
+        for (Method declaredMethod : testCase.getTestClass().getRealClass().getMethods()) {
             if (declaredMethod.getAnnotation(annotationClass) != null) {
                 try {
                     declaredMethod.invoke(testCase.getInstance(), reflectionInjectorHelper.getMethodArguments(testContext, declaredMethod));


### PR DESCRIPTION
Allowing usage of
- @BeforeTestWithContext 
- @AfterTestWithContext 

in superclasses. It's often used to build a common set of tests and their initialisation for multiple contexts.