### PR TITLE
Add GitHub actions workflow skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: ['8', '11', '15']
+    steps:
+    - uses: actions/checkout@v2
+    - name: ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}


### PR DESCRIPTION
This adds a minimal workflow so that the PR that actually adds the workflow implementation can be "tested" (since workflows don't run unless they exist in master).