### PR TITLE
Allow loading multiple docs from a yaml config file

### DIFF
--- a/tempto-core/src/main/java/io/trino/tempto/internal/configuration/TestConfigurationFactory.java
+++ b/tempto-core/src/main/java/io/trino/tempto/internal/configuration/TestConfigurationFactory.java
@@ -22,6 +22,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.Optional;
 
 import static io.trino.tempto.internal.configuration.EmptyConfiguration.emptyConfiguration;
@@ -62,8 +63,9 @@ public class TestConfigurationFactory
             if (!testConfigurationStream.isPresent()) {
                 throw new IllegalArgumentException("Unable find to configuration: " + testConfigurationUri);
             }
-            Configuration parsedConfiguration = parseConfiguration(testConfigurationStream.get());
-            configuration = new HierarchicalConfiguration(configuration, parsedConfiguration);
+            for (Configuration parsedConfiguration : parseConfiguration(testConfigurationStream.get())) {
+                configuration = new HierarchicalConfiguration(configuration, parsedConfiguration);
+            }
         }
         return configuration;
     }
@@ -95,10 +97,10 @@ public class TestConfigurationFactory
         return Optional.ofNullable(TestConfigurationFactory.class.getResourceAsStream(path));
     }
 
-    private static YamlConfiguration parseConfiguration(InputStream testConfigurationStream)
+    private static List<YamlConfiguration> parseConfiguration(InputStream testConfigurationStream)
     {
         try (InputStream configurationInputStream = testConfigurationStream) {
-            return new YamlConfiguration(configurationInputStream);
+            return YamlConfiguration.loadAll(configurationInputStream);
         }
         catch (IOException e) {
             throw new RuntimeException("could not parse configuration file", e);

--- a/tempto-core/src/test/groovy/io/trino/tempto/internal/configuration/YamlConfigurationTest.groovy
+++ b/tempto-core/src/test/groovy/io/trino/tempto/internal/configuration/YamlConfigurationTest.groovy
@@ -47,6 +47,27 @@ list:
         configuration.getStringOrList('list') == ['element1', 'element2']
     }
 
+    def createMultiple()
+    {
+        setup:
+        def configurations = YamlConfiguration.loadAll("""\
+a: 1
+list:
+    - element1
+    - element2   
+---
+b: 2
+""")
+        expect:
+        configurations[0].listKeys() == ['a', 'list'] as Set
+        configurations[0].getInt('a') == Optional.of(1)
+        configurations[0].isList('list')
+        configurations[0].getStringList('list') == ['element1', 'element2']
+        configurations[0].getStringOrList('list') == ['element1', 'element2']
+        configurations[1].listKeys() == ['b'] as Set
+        configurations[1].getInt('b') == Optional.of(2)
+    }
+
     def createEmpty()
     {
         setup:


### PR DESCRIPTION
Instead of providing a list of config files, sometimes it might be easier to concatenate them into a single file (in the same order).

This PR adds support for that.

My use case is getting all the configs out of the test container used in Trino to allow running tests directly on the developer's computer (from an IDE), not in a container.