### PR TITLE
Support database configs without the jdbc password

### DIFF
--- a/tempto-core/src/main/java/io/trino/tempto/internal/query/JdbcConnectionsConfiguration.java
+++ b/tempto-core/src/main/java/io/trino/tempto/internal/query/JdbcConnectionsConfiguration.java
@@ -53,18 +53,19 @@ public class JdbcConnectionsConfiguration
     {
         Configuration connectionConfiguration = getDatabaseConnectionSubConfiguration(connectionName);
 
-        return JdbcConnectivityParamsState.builder()
+        JdbcConnectivityParamsState.Builder builder = JdbcConnectivityParamsState.builder()
                 .setName(connectionName)
                 .setDriverClass(connectionConfiguration.getStringMandatory(JDBC_DRIVER_CLASS))
                 .setUrl(connectionConfiguration.getStringMandatory(JDBC_URL_KEY))
                 .setUser(connectionConfiguration.getStringMandatory(JDBC_USER_KEY))
-                .setPassword(connectionConfiguration.getStringMandatory(JDBC_PASSWORD_KEY))
                 .setPooling(connectionConfiguration.getBoolean(JDBC_POOLING_KEY).orElse(false))
                 .setJar(connectionConfiguration.getString(JDBC_JAR))
                 .setPrepareStatements(connectionConfiguration.getStringOrList(PREPARE_STATEMENT_KEY))
                 .setKerberosPrincipal(connectionConfiguration.getString(KERBEROS_PRINCIPAL_KEY))
-                .setKerberosKeytab(connectionConfiguration.getString(KERBEROS_KEYTAB_KEY))
-                .build();
+                .setKerberosKeytab(connectionConfiguration.getString(KERBEROS_KEYTAB_KEY));
+        Optional<String> password = connectionConfiguration.getString(JDBC_PASSWORD_KEY);
+        password.ifPresent(builder::setPassword);
+        return builder.build();
     }
 
     private Configuration getDatabaseConnectionSubConfiguration(String connectionName)

--- a/tempto-core/src/test/groovy/io/trino/tempto/internal/query/JdbcConnectionsConfigurationTest.groovy
+++ b/tempto-core/src/test/groovy/io/trino/tempto/internal/query/JdbcConnectionsConfigurationTest.groovy
@@ -41,6 +41,11 @@ databases:
     kerberos_principal: HIVE@EXAMPLE.COM
     kerberos_keytab: example.keytab
 
+  c:
+    jdbc_driver_class: com.acme.ADriver
+    jdbc_url: jdbc:c://localhost:8080
+    jdbc_user: cuser
+
   b_alias:
     alias: b
 
@@ -85,6 +90,15 @@ databases:
                     .setKerberosKeytab(Optional.of('example.keytab'))
                     .build();
 
+    private static final def EXPECTED_C_JDBC_CONNECTIVITY_PARAMS =
+            JdbcConnectivityParamsState.builder()
+                    .setName('c')
+                    .setDriverClass('com.acme.ADriver')
+                    .setUrl('jdbc:c://localhost:8080')
+                    .setUser('cuser')
+                    .setPassword('')
+                    .build()
+
     private static final def EXPECTED_B_ALIAS_JDBC_CONNECTIVITY_PARAMS =
             JdbcConnectivityParamsState.builder()
                     .setName('b_alias')
@@ -104,7 +118,7 @@ databases:
     def "list database connection configurations"()
     {
         expect:
-        jdbcConnectionConfiguration.getDefinedJdbcConnectionNames() == ['a', 'b', 'b_alias'] as Set
+        jdbcConnectionConfiguration.getDefinedJdbcConnectionNames() == ['a', 'b', 'c', 'b_alias'] as Set
     }
 
     def "get connection configuration"()
@@ -112,10 +126,12 @@ databases:
         setup:
         def a = jdbcConnectionConfiguration.getConnectionConfiguration('a')
         def b = jdbcConnectionConfiguration.getConnectionConfiguration('b')
+        def c = jdbcConnectionConfiguration.getConnectionConfiguration('c')
 
         expect:
         a == EXPECTED_A_JDBC_CONNECTIVITY_PARAMS
         b == EXPECTED_B_JDBC_CONNECTIVITY_PARAMS
+        c == EXPECTED_C_JDBC_CONNECTIVITY_PARAMS
     }
 
     def "get connection configuration for alias"()

--- a/tempto-examples/src/main/resources/tempto-configuration-invalid-ssh-and-psql.yaml
+++ b/tempto-examples/src/main/resources/tempto-configuration-invalid-ssh-and-psql.yaml
@@ -43,7 +43,6 @@ databases:
     jdbc_driver_class: io.trino.jdbc.TrinoDriver
     jdbc_url: jdbc:trino://${cluster.trino}:8080/hive/default
     jdbc_user: hdfs
-    jdbc_password: "***empty***"
     jdbc_pooling: false
 
   psql:

--- a/tempto-examples/src/main/resources/tempto-configuration-read-only.yaml
+++ b/tempto-examples/src/main/resources/tempto-configuration-read-only.yaml
@@ -12,7 +12,6 @@ databases:
     jdbc_driver_class: io.trino.jdbc.TrinoDriver
     jdbc_url: jdbc:trino://${cluster.trino}:8080/hive/default
     jdbc_user: hdfs
-    jdbc_password: "***empty***"
 
 ssh:
   identity: ${IDENTITY}

--- a/tempto-examples/src/main/resources/tempto-configuration.yaml
+++ b/tempto-examples/src/main/resources/tempto-configuration.yaml
@@ -39,7 +39,6 @@ databases:
     jdbc_driver_class: io.trino.jdbc.TrinoDriver
     jdbc_url: jdbc:trino://${cluster.trino}:8080/hive/default
     jdbc_user: hdfs
-    jdbc_password: "***empty***"
     jdbc_pooling: false
     table_manager_type: jdbc
 
@@ -47,7 +46,6 @@ databases:
     jdbc_driver_class: io.trino.jdbc.TrinoDriver
     jdbc_url: jdbc:trino://${cluster.trino}:8080/hive/tpcds
     jdbc_user: hdfs
-    jdbc_password: "***empty***"
     jdbc_pooling: false
 
   psql:


### PR DESCRIPTION
This is to address this comment: https://github.com/trinodb/trino/blob/master/client/trino-jdbc/src/main/java/io/trino/jdbc/TrinoDriverUri.java#L262

I couldn't make the existing tests fail when setting the `jdbc_password` to an empty string, so it might have already been fixed before. This PR allows skipping setting the `jdbc_password` key at all.