### PR TITLE
Update Byte Buddy from 1.12.6 to 1.12.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.12.6</version>
+                <version>1.12.13</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This is required to update Airlift in Trino to 218, which also includes Byte Buddy 1.12.13

https://github.com/trinodb/trino/pull/13571