### PR TITLE
Fix NullPointerException in ProgressLoggingListener

### DIFF
--- a/tempto-core/src/main/java/io/trino/tempto/internal/listeners/ProgressLoggingListener.java
+++ b/tempto-core/src/main/java/io/trino/tempto/internal/listeners/ProgressLoggingListener.java
@@ -124,7 +124,7 @@ public class ProgressLoggingListener
             return "";
         }
 
-        return format(" [%s]", Joiner.on(", ").join(testParameters));
+        return format(" [%s]", Joiner.on(", ").useForNull("null").join(testParameters));
     }
 
     private static String formatDuration(long durationInMillis)


### PR DESCRIPTION
NullPointerException happens when data providers contain `null` in the parameter. 