### PR TITLE
Update airbase to 134

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>119</version>
+        <version>134</version>
     </parent>
 
     <groupId>io.trino.tempto</groupId>
@@ -172,7 +172,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.12.13</version>
+                <version>1.12.21</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>1.15</version>
+                <version>2.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR updates Tempto to include new version of Snakeyaml not affected by https://www.cve.org/CVERecord?id=CVE-2022-1471