### PR TITLE
Resolve static import conflicts for assertThat in product tests

### DIFF
--- a/tempto-core/src/main/java/io/trino/tempto/assertions/QueryAssert.java
+++ b/tempto-core/src/main/java/io/trino/tempto/assertions/QueryAssert.java
@@ -23,6 +23,7 @@ import io.trino.tempto.query.QueryExecutor;
 import io.trino.tempto.query.QueryResult;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractThrowableAssert;
+import org.assertj.core.api.AssertProvider;
 import org.assertj.core.api.Assertions;
 import org.intellij.lang.annotations.Language;
 import org.slf4j.Logger;
@@ -36,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Strings.nullToEmpty;
@@ -71,7 +73,11 @@ public class QueryAssert
         this.columnTypes = actual.getColumnTypes();
     }
 
+    /**
+     * Use {@link Assertions#assertThat(AssertProvider)}.
+     */
     @CheckReturnValue
+    @Deprecated
     public static QueryAssert assertThat(QueryResult queryResult)
     {
         return new QueryAssert(queryResult);

--- a/tempto-core/src/main/java/io/trino/tempto/query/QueryResult.java
+++ b/tempto-core/src/main/java/io/trino/tempto/query/QueryResult.java
@@ -20,6 +20,8 @@ import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import io.trino.tempto.assertions.QueryAssert;
+import org.assertj.core.api.AssertProvider;
 
 import java.sql.JDBCType;
 import java.sql.ResultSet;
@@ -46,6 +48,8 @@ import static java.util.stream.Collectors.toList;
  * It stores all returned values, column names and their types as {@link java.sql.JDBCType}.
  */
 public class QueryResult
+        // Allow using query results with Assertions.assertThat, avoiding import conflicts
+        implements AssertProvider<QueryAssert>
 {
     private final List<JDBCType> columnTypes;
     private final BiMap<String, Integer> columnNamesIndexes;
@@ -147,6 +151,12 @@ public class QueryResult
                 .add("columnTypes", columnTypes)
                 .add("values", values)
                 .toString();
+    }
+
+    @Override
+    public QueryAssert assertThat()
+    {
+        return QueryAssert.assertThat(this);
     }
 
     /**


### PR DESCRIPTION
Use `AssertProvider` interface, so that generic `assertThat` from assertj can be used instead of custom `QueryAssert.assertThat`. They have same name, so only one can be imported statically.