### PR TITLE
Fix Tempto before/after annotation names

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ public class InjectionTest
     @Inject
     MutableTablesState mutableTablesState;
 
-    @BeforeTestWithContext
+    @BeforeMethodWithContext
     @Inject
     public void setUp(
             ImmutableTablesState immutableTablesState,

--- a/tempto-core/src/main/java/io/trino/tempto/AfterMethodWithContext.java
+++ b/tempto-core/src/main/java/io/trino/tempto/AfterMethodWithContext.java
@@ -15,7 +15,6 @@
 package io.trino.tempto;
 
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterTest;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -27,12 +26,7 @@ import java.lang.annotation.Target;
  * but before Tempto context has been destroyed.
  *
  * @see AfterMethod
- * @deprecated The annotation mimics {@link AfterMethod} but is named after {@link AfterTest},
- * which is confusing. Use {@link AfterMethodWithContext} instead.
  */
-@Deprecated
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
-public @interface AfterTestWithContext
-{
-}
+public @interface AfterMethodWithContext {}

--- a/tempto-core/src/main/java/io/trino/tempto/BeforeMethodWithContext.java
+++ b/tempto-core/src/main/java/io/trino/tempto/BeforeMethodWithContext.java
@@ -14,8 +14,7 @@
 
 package io.trino.tempto;
 
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeMethod;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -23,16 +22,11 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotates methods that should be invoked after each test method (like {@link @AfterMethod}),
- * but before Tempto context has been destroyed.
+ * Annotates methods that should be invoked before each test method (like {@link @BeforeMethod}),
+ * but after Tempto context has been injected.
  *
- * @see AfterMethod
- * @deprecated The annotation mimics {@link AfterMethod} but is named after {@link AfterTest},
- * which is confusing. Use {@link AfterMethodWithContext} instead.
+ * @see BeforeMethod
  */
-@Deprecated
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
-public @interface AfterTestWithContext
-{
-}
+public @interface BeforeMethodWithContext {}

--- a/tempto-core/src/main/java/io/trino/tempto/BeforeTestWithContext.java
+++ b/tempto-core/src/main/java/io/trino/tempto/BeforeTestWithContext.java
@@ -14,11 +14,23 @@
 
 package io.trino.tempto;
 
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Annotates methods that should be invoked before each test method (like {@link @BeforeMethod}),
+ * but after Tempto context has been injected.
+ *
+ * @see BeforeMethod
+ * @deprecated The annotation mimics {@link BeforeMethod} but is named after {@link BeforeTest},
+ * which is confusing. Use {@link BeforeMethodWithContext} instead.
+ */
+@Deprecated
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD})
 public @interface BeforeTestWithContext

--- a/tempto-core/src/test/groovy/io/trino/tempto/internal/initialization/TestInitializationListenerTest.groovy
+++ b/tempto-core/src/test/groovy/io/trino/tempto/internal/initialization/TestInitializationListenerTest.groovy
@@ -213,7 +213,7 @@ class TestInitializationListenerTest
     static class TestClassOverrideAdditionalAnnotatedMethod
             extends TestClass
     {
-        @BeforeTestWithContext
+        @BeforeMethodWithContext
         void beforeMethodAdditional()
         {
             EVENTS.add(new Event(BEFORE_METHOD_OVERRIDE, this));
@@ -224,14 +224,14 @@ class TestInitializationListenerTest
             extends TestClass
     {
         @Override
-        @BeforeTestWithContext
+        @BeforeMethodWithContext
         void beforeMethod()
         {
             EVENTS.add(new Event(BEFORE_METHOD_OVERRIDE, this));
         }
 
         @Override
-        @AfterTestWithContext
+        @AfterMethodWithContext
         void afterMethod()
         {
             EVENTS.add(new Event(AFTER_METHOD_OVERRIDE, this));
@@ -245,13 +245,13 @@ class TestInitializationListenerTest
         @Inject
         TestContext testContext
 
-        @BeforeTestWithContext
+        @BeforeMethodWithContext
         void beforeMethod()
         {
             EVENTS.add(new Event(BEFORE_METHOD, this));
         }
 
-        @AfterTestWithContext
+        @AfterMethodWithContext
         void afterMethod()
         {
             EVENTS.add(new Event(AFTER_METHOD, this));

--- a/tempto-examples/src/main/java/io/trino/tempto/examples/InjectionTest.java
+++ b/tempto-examples/src/main/java/io/trino/tempto/examples/InjectionTest.java
@@ -15,7 +15,9 @@
 package io.trino.tempto.examples;
 
 import com.google.inject.Inject;
+import io.trino.tempto.AfterMethodWithContext;
 import io.trino.tempto.AfterTestWithContext;
+import io.trino.tempto.BeforeMethodWithContext;
 import io.trino.tempto.BeforeTestWithContext;
 import io.trino.tempto.ProductTest;
 import io.trino.tempto.fulfillment.table.ImmutableTablesState;
@@ -32,7 +34,7 @@ public class InjectionTest
     @Inject
     MutableTablesState mutableTablesState;
 
-    @BeforeTestWithContext
+    @BeforeMethodWithContext
     @Inject
     public void setUp(
             ImmutableTablesState immutableTablesState,
@@ -49,7 +51,7 @@ public class InjectionTest
         assertThat(mutableTablesState).isNotNull();
     }
 
-    @AfterTestWithContext
+    @AfterMethodWithContext
     @Inject
     public void tearDown(
             ImmutableTablesState immutableTablesState,

--- a/tempto-examples/src/main/java/io/trino/tempto/examples/ResourcesTest.java
+++ b/tempto-examples/src/main/java/io/trino/tempto/examples/ResourcesTest.java
@@ -14,6 +14,7 @@
 
 package io.trino.tempto.examples;
 
+import io.trino.tempto.BeforeMethodWithContext;
 import io.trino.tempto.BeforeTestWithContext;
 import io.trino.tempto.ProductTest;
 import org.testng.annotations.Test;
@@ -28,7 +29,7 @@ public class ResourcesTest
     private boolean testResource;
     private boolean suiteResource;
 
-    @BeforeTestWithContext
+    @BeforeMethodWithContext
     public void suiteResources()
     {
         suiteResource = true;

--- a/tempto-examples/src/main/java/io/trino/tempto/examples/SimpleQueryTest.java
+++ b/tempto-examples/src/main/java/io/trino/tempto/examples/SimpleQueryTest.java
@@ -16,7 +16,9 @@ package io.trino.tempto.examples;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import io.trino.tempto.AfterMethodWithContext;
 import io.trino.tempto.AfterTestWithContext;
+import io.trino.tempto.BeforeMethodWithContext;
 import io.trino.tempto.BeforeTestWithContext;
 import io.trino.tempto.ProductTest;
 import io.trino.tempto.Requirement;
@@ -75,13 +77,13 @@ public class SimpleQueryTest
         // just to check if having @AfterEach method does not break anything
     }
 
-    @BeforeTestWithContext
+    @BeforeMethodWithContext
     public void beforeTest()
     {
         assertThat(testContextIfSet().isPresent()).isTrue();
     }
 
-    @AfterTestWithContext
+    @AfterMethodWithContext
     public void afterTest()
     {
         assertThat(testContextIfSet().isPresent()).isTrue();


### PR DESCRIPTION
`@BeforeTestWithContext` mimics `@BeforeMethod` but is named after `@BeforeTest` which is confusing. `@BeforeMethod` is invoked just before a test method, while `@BeforeTest` is invoked before any tests are attempted, so even before any `@BeforeClass` are called.

Similar for `@AfterTestWithContext` / `@AfterMethod` / `@AfterTest`.

TestNG method invocation order example

```
Test class 1: @BeforeTest
Test class 2: @BeforeTest
Test class 1: @BeforeCass
Test class 1: @BeforeMethod
Test class 1: a test 1
Test class 1: @AfterMethod
Test class 1: @BeforeMethod
Test class 1: a test 2
Test class 1: @AfterMethod
Test class 1: @afterclass
Test class 2: @BeforeCass
Test class 2: @BeforeMethod
Test class 2: a test 1
Test class 2: @AfterMethod
Test class 2: @BeforeMethod
Test class 2: a test 2
Test class 2: @AfterMethod
Test class 2: @afterclass
Test class 1: @AfterTest
Test class 2: @AfterTest
```

Relates to https://github.com/trinodb/trino/pull/17650