### PR TITLE
Refactor tempto to use com.google.inject

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>io.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>134</version>
+        <version>141</version>
     </parent>
 
     <groupId>io.trino.tempto</groupId>

--- a/tempto-core/pom.xml
+++ b/tempto-core/pom.xml
@@ -62,11 +62,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>
@@ -152,14 +147,19 @@
             <scope>provided</scope>
         </dependency>
 
-        <!-- needed at runtime -->
+        <!-- used by tests but also needed transitively -->
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
             <scope>runtime</scope>
         </dependency>
 
-        <!-- for testing -->
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy</artifactId>

--- a/tempto-core/src/main/java/io/trino/tempto/fulfillment/table/ReadOnlyTableManager.java
+++ b/tempto-core/src/main/java/io/trino/tempto/fulfillment/table/ReadOnlyTableManager.java
@@ -16,8 +16,8 @@ package io.trino.tempto.fulfillment.table;
 import com.google.inject.Inject;
 import io.trino.tempto.internal.fulfillment.table.TableName;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
+import com.google.inject.name.Named;
+import com.google.inject.Singleton;
 
 /**
  * Table manager for read only databases.

--- a/tempto-core/src/main/java/io/trino/tempto/internal/fulfillment/command/TestCommandFulfiller.java
+++ b/tempto-core/src/main/java/io/trino/tempto/internal/fulfillment/command/TestCommandFulfiller.java
@@ -17,7 +17,7 @@ package io.trino.tempto.internal.fulfillment.command;
 import io.trino.tempto.fulfillment.RequirementFulfiller;
 import io.trino.tempto.fulfillment.command.TestCommandRequirement;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 @RequirementFulfiller.TestLevelFulfiller
 public class TestCommandFulfiller

--- a/tempto-core/src/main/java/io/trino/tempto/internal/fulfillment/table/cassandra/CassandraTableManager.java
+++ b/tempto-core/src/main/java/io/trino/tempto/internal/fulfillment/table/cassandra/CassandraTableManager.java
@@ -27,8 +27,8 @@ import io.trino.tempto.internal.query.CassandraQueryExecutor;
 import io.trino.tempto.util.Lazy;
 import org.slf4j.Logger;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
+import com.google.inject.name.Named;
+import com.google.inject.Singleton;
 
 import java.util.List;
 import java.util.Optional;

--- a/tempto-core/src/main/java/io/trino/tempto/internal/fulfillment/table/hive/HiveTableManager.java
+++ b/tempto-core/src/main/java/io/trino/tempto/internal/fulfillment/table/hive/HiveTableManager.java
@@ -28,8 +28,8 @@ import io.trino.tempto.query.QueryExecutor;
 import io.trino.tempto.query.QueryResult;
 import org.slf4j.Logger;
 
-import javax.inject.Named;
-import javax.inject.Singleton;
+import com.google.inject.name.Named;
+import com.google.inject.Singleton;
 
 import java.net.URI;
 import java.net.URISyntaxException;

--- a/tempto-core/src/main/java/io/trino/tempto/internal/fulfillment/table/jdbc/JdbcTableManager.java
+++ b/tempto-core/src/main/java/io/trino/tempto/internal/fulfillment/table/jdbc/JdbcTableManager.java
@@ -31,7 +31,7 @@ import io.trino.tempto.query.QueryExecutor;
 import io.trino.tempto.query.QueryResult;
 import org.slf4j.Logger;
 
-import javax.inject.Named;
+import com.google.inject.name.Named;
 
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;

--- a/tempto-core/src/main/java/io/trino/tempto/internal/hadoop/hdfs/DefaultHdfsDataSourceWriter.java
+++ b/tempto-core/src/main/java/io/trino/tempto/internal/hadoop/hdfs/DefaultHdfsDataSourceWriter.java
@@ -19,7 +19,7 @@ import io.trino.tempto.hadoop.hdfs.HdfsClient;
 import io.trino.tempto.hadoop.hdfs.HdfsClient.RepeatableContentProducer;
 import org.slf4j.Logger;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 import static org.slf4j.LoggerFactory.getLogger;
 

--- a/tempto-core/src/main/java/io/trino/tempto/internal/query/QueryExecutorModuleProvider.java
+++ b/tempto-core/src/main/java/io/trino/tempto/internal/query/QueryExecutorModuleProvider.java
@@ -28,7 +28,7 @@ import io.trino.tempto.query.JdbcQueryExecutor;
 import io.trino.tempto.query.QueryExecutor;
 import io.trino.tempto.query.QueryExecutorDispatcher;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 import java.util.Map;
 import java.util.Set;

--- a/tempto-core/src/main/java/io/trino/tempto/query/JdbcQueryExecutor.java
+++ b/tempto-core/src/main/java/io/trino/tempto/query/JdbcQueryExecutor.java
@@ -17,7 +17,7 @@ package io.trino.tempto.query;
 import io.trino.tempto.context.TestContext;
 import org.slf4j.Logger;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;

--- a/tempto-core/src/main/java/io/trino/tempto/util/Lazy.java
+++ b/tempto-core/src/main/java/io/trino/tempto/util/Lazy.java
@@ -15,20 +15,20 @@
 package io.trino.tempto.util;
 
 import javax.annotation.concurrent.ThreadSafe;
-import javax.inject.Provider;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
 @ThreadSafe
 public class Lazy<T>
-        implements Provider<T>
+        implements Supplier<T>
 {
-    private final Provider<T> provider;
+    private final Supplier<T> provider;
     private T instance;
 
-    public Lazy(Provider<T> provider)
+    public Lazy(Supplier<T> provider)
     {
         this.provider = requireNonNull(provider, "provider is null");
     }

--- a/tempto-core/src/test/groovy/io/trino/tempto/internal/ReflectionInjectorHelperTest.groovy
+++ b/tempto-core/src/test/groovy/io/trino/tempto/internal/ReflectionInjectorHelperTest.groovy
@@ -17,9 +17,11 @@ package io.trino.tempto.internal
 import com.google.common.collect.ImmutableList
 import com.google.inject.AbstractModule
 import com.google.inject.ConfigurationException
+import com.google.inject.Inject
 import com.google.inject.Injector
 import com.google.inject.Key
 import com.google.inject.TypeLiteral
+import com.google.inject.name.Named
 import io.trino.tempto.Requirement
 import io.trino.tempto.context.State
 import io.trino.tempto.context.TestContext
@@ -29,8 +31,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 
-import javax.inject.Inject
-import javax.inject.Named
 import java.lang.reflect.Method
 
 import static com.google.inject.Guice.createInjector
@@ -132,20 +132,20 @@ class ReflectionInjectorHelperTest
         assert key == 'value';
     }
 
-    @javax.inject.Inject
-    void useKey2(@javax.inject.Named('key2') String key)
+    @jakarta.inject.Inject
+    void useKey2(@jakarta.inject.Named('key2') String key)
     {
         assert key == 'value2';
     }
 
-    @Disabled
     @Test
+    @Disabled
     void canInjectStringListToMethod()
     {
         injectAndCallMethod('useStringList', List)
     }
 
-    @javax.inject.Inject
+    @Inject
     void useStringList(List<String> stringList)
     {
         assert stringList.size() == 3 && stringList.containsAll(['ala', 'ma', 'kota'])

--- a/tempto-examples/pom.xml
+++ b/tempto-examples/pom.xml
@@ -67,11 +67,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>

--- a/tempto-examples/src/main/java/io/trino/tempto/examples/ExampleSshClientUsage.java
+++ b/tempto-examples/src/main/java/io/trino/tempto/examples/ExampleSshClientUsage.java
@@ -21,7 +21,7 @@ import io.trino.tempto.ssh.SshClient;
 import io.trino.tempto.ssh.SshClientFactory;
 import org.testng.annotations.Test;
 
-import javax.inject.Named;
+import com.google.inject.name.Named;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;

--- a/tempto-examples/src/main/java/io/trino/tempto/examples/InjectionTest.java
+++ b/tempto-examples/src/main/java/io/trino/tempto/examples/InjectionTest.java
@@ -22,7 +22,7 @@ import io.trino.tempto.fulfillment.table.ImmutableTablesState;
 import io.trino.tempto.fulfillment.table.MutableTablesState;
 import org.testng.annotations.Test;
 
-import javax.inject.Named;
+import com.google.inject.name.Named;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/tempto-examples/src/main/java/io/trino/tempto/examples/PostgresqlQueryTest.java
+++ b/tempto-examples/src/main/java/io/trino/tempto/examples/PostgresqlQueryTest.java
@@ -30,7 +30,7 @@ import io.trino.tempto.fulfillment.table.jdbc.RelationalTableDefinition;
 import io.trino.tempto.query.QueryExecutor;
 import org.testng.annotations.Test;
 
-import javax.inject.Named;
+import com.google.inject.name.Named;
 
 import java.util.List;
 

--- a/tempto-kafka/pom.xml
+++ b/tempto-kafka/pom.xml
@@ -29,11 +29,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>

--- a/tempto-kafka/src/main/java/io/trino/tempto/fulfillment/table/kafka/KafkaTableManager.java
+++ b/tempto-kafka/src/main/java/io/trino/tempto/fulfillment/table/kafka/KafkaTableManager.java
@@ -30,9 +30,9 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Singleton;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import com.google.inject.Singleton;
 
 import java.util.Iterator;
 import java.util.Properties;

--- a/tempto-ldap/pom.xml
+++ b/tempto-ldap/pom.xml
@@ -29,11 +29,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.inject</groupId>
-            <artifactId>javax.inject</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.google.inject</groupId>
             <artifactId>guice</artifactId>
         </dependency>

--- a/tempto-ldap/src/main/java/io/trino/tempto/internal/fulfillment/ldap/DefaultLdapObjectEntryManager.java
+++ b/tempto-ldap/src/main/java/io/trino/tempto/internal/fulfillment/ldap/DefaultLdapObjectEntryManager.java
@@ -18,8 +18,8 @@ import io.trino.tempto.fulfillment.ldap.LdapObjectDefinition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.inject.Inject;
-import javax.inject.Named;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
 import javax.naming.Context;
 import javax.naming.NameAlreadyBoundException;
 import javax.naming.NamingException;


### PR DESCRIPTION
This change:

- updates airbase to 140 with Guice 6.0.0
- switches injection annotation to be Guice-based
- adds minimal support for jakarta.inject annotations