### PR TITLE
Upgrade to Java 17 and use getPlatformClassLoader for jar parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ paradigm and AssertJ style assertion) or by providing query files with expected 
 
 ## Prerequisites
 
-To use Tempto you need a Java 1.8 runtime.
+To use Tempto you need a Java 17 runtime.
 
 Other dependencies will vary based on the set of features you are using.
 

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,8 @@
         <air.check.skip-modernizer>true</air.check.skip-modernizer>
         <air.check.skip-spotbugs>true</air.check.skip-spotbugs>
         <air.check.skip-pmd>true</air.check.skip-pmd>
+
+        <project.build.targetJdk>17</project.build.targetJdk>
     </properties>
 
     <modules>

--- a/tempto-core/src/main/java/io/trino/tempto/internal/query/JdbcUtils.java
+++ b/tempto-core/src/main/java/io/trino/tempto/internal/query/JdbcUtils.java
@@ -27,6 +27,7 @@ import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
 
+import static java.lang.ClassLoader.getPlatformClassLoader;
 import static java.sql.DriverManager.getConnection;
 
 public final class JdbcUtils
@@ -89,12 +90,11 @@ public final class JdbcUtils
     private static ClassLoader getDriverClassLoader(JdbcConnectivityParamsState jdbcParamsState)
     {
         try {
-            ClassLoader myClassLoader = JdbcUtils.class.getClassLoader();
             if (!jdbcParamsState.jar.isPresent()) {
-                return myClassLoader;
+                return JdbcUtils.class.getClassLoader();
             }
             URL jarURL = new File(jdbcParamsState.jar.get()).toURL();
-            return URLClassLoader.newInstance(new URL[] {jarURL}, myClassLoader);
+            return URLClassLoader.newInstance(new URL[] {jarURL}, getPlatformClassLoader());
         }
         catch (MalformedURLException e) {
             throw new RuntimeException("could not create classloader for file" + jdbcParamsState.jar.get(), e);

--- a/tempto-examples/docker/docker-compose.yml
+++ b/tempto-examples/docker/docker-compose.yml
@@ -70,7 +70,7 @@ services:
       - 'trino-master'
 
   runner:
-    image: 'ghcr.io/trinodb/testing/centos7-oj11:53'
+    image: 'ghcr.io/trinodb/testing/centos7-oj17:82'
     ports:
       - '5005:5005'
     volumes:


### PR DESCRIPTION
https://github.com/trinodb/trino/pull/17667 is trying to download jar from maven programatically and use `jar` parameter, but `JdbcUtils.class.getClassLoader()` caused class loader issue. 