### PR TITLE
Remove xml-bind usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
             <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
-                <version>1.12.21</version>
+                <version>1.14.6</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
             <dependency>
                 <groupId>org.yaml</groupId>
                 <artifactId>snakeyaml</artifactId>
-                <version>2.0</version>
+                <version>2.1</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -167,12 +167,6 @@
             </dependency>
 
             <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>2.3.1</version>
-            </dependency>
-
-            <dependency>
                 <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy</artifactId>
                 <version>1.12.21</version>

--- a/tempto-core/pom.xml
+++ b/tempto-core/pom.xml
@@ -117,11 +117,6 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
         </dependency>

--- a/tempto-core/src/main/java/io/trino/tempto/internal/query/QueryRowMapper.java
+++ b/tempto-core/src/main/java/io/trino/tempto/internal/query/QueryRowMapper.java
@@ -16,13 +16,12 @@ package io.trino.tempto.internal.query;
 
 import io.trino.tempto.assertions.QueryAssert.Row;
 
-import javax.xml.bind.DatatypeConverter;
-
 import java.math.BigDecimal;
 import java.sql.Date;
 import java.sql.JDBCType;
 import java.sql.Time;
 import java.sql.Timestamp;
+import java.util.HexFormat;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -115,7 +114,7 @@ public class QueryRowMapper
 
     private byte[] convertBinary(String value)
     {
-        return DatatypeConverter.parseHexBinary(value);
+        return HexFormat.of().parseHex(value);
     }
 
     private Boolean convertBoolean(String value)


### PR DESCRIPTION
It's imported for a single use-case which can be replaced by JDK17 HexFormat