### PR TITLE
Update TestNG to version 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,7 @@
         <air.check.skip-pmd>true</air.check.skip-pmd>
 
         <project.build.targetJdk>21</project.build.targetJdk>
+        <dep.testng.version>7.10.2</dep.testng.version>
     </properties>
 
     <dependencyManagement>

--- a/tempto-core/src/main/java/io/trino/tempto/internal/initialization/DelegateTestNGMethod.java
+++ b/tempto-core/src/main/java/io/trino/tempto/internal/initialization/DelegateTestNGMethod.java
@@ -18,6 +18,7 @@ import org.testng.IClass;
 import org.testng.IRetryAnalyzer;
 import org.testng.ITestClass;
 import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
 import org.testng.internal.ConstructorOrMethod;
 import org.testng.xml.XmlTest;
 
@@ -55,23 +56,9 @@ public abstract class DelegateTestNGMethod
     }
 
     @Override
-    @Deprecated
-    public Method getMethod()
-    {
-        return delegate.getMethod();
-    }
-
-    @Override
     public String getMethodName()
     {
         return delegate.getMethodName();
-    }
-
-    @Override
-    @Deprecated
-    public Object[] getInstances()
-    {
-        return delegate.getInstances();
     }
 
     @Override
@@ -225,12 +212,6 @@ public abstract class DelegateTestNGMethod
     }
 
     @Override
-    public int getTotalInvocationCount()
-    {
-        return delegate.getTotalInvocationCount();
-    }
-
-    @Override
     public int getSuccessPercentage()
     {
         return delegate.getSuccessPercentage();
@@ -324,18 +305,6 @@ public abstract class DelegateTestNGMethod
     public int getParameterInvocationCount()
     {
         return delegate.getParameterInvocationCount();
-    }
-
-    @Override
-    public IRetryAnalyzer getRetryAnalyzer()
-    {
-        return delegate.getRetryAnalyzer();
-    }
-
-    @Override
-    public void setRetryAnalyzer(IRetryAnalyzer retryAnalyzer)
-    {
-        delegate.setRetryAnalyzer(retryAnalyzer);
     }
 
     @Override
@@ -441,15 +410,39 @@ public abstract class DelegateTestNGMethod
     }
 
     @Override
-    public int compareTo(Object o)
-    {
-        return delegate.compareTo(o);
-    }
-
-    @Override
     public String toString()
     {
         return delegate.toString();
+    }
+
+    @Override
+    public IRetryAnalyzer getRetryAnalyzer(ITestResult iTestResult)
+    {
+        return delegate.getRetryAnalyzer(iTestResult);
+    }
+
+    @Override
+    public void setRetryAnalyzerClass(Class<? extends IRetryAnalyzer> aClass)
+    {
+        delegate.setRetryAnalyzerClass(aClass);
+    }
+
+    @Override
+    public Class<? extends IRetryAnalyzer> getRetryAnalyzerClass()
+    {
+        return delegate.getRetryAnalyzerClass();
+    }
+
+    @Override
+    public int getInterceptedPriority()
+    {
+        return delegate.getInterceptedPriority();
+    }
+
+    @Override
+    public void setInterceptedPriority(int i)
+    {
+        delegate.setInterceptedPriority(i);
     }
 
     @Override

--- a/tempto-examples/docker/ssh/Dockerfile
+++ b/tempto-examples/docker/ssh/Dockerfile
@@ -1,5 +1,10 @@
 FROM ghcr.io/trinodb/testing/centos7-oj11:53
 
+# TODO: Remove when updating to newer base image
+# replace mirrorlist.centos.org and mirror.centos.org with vault.centos.org
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum install -y openssh-server openssh-clients passwd
 RUN echo s3cr37_p@55 | passwd --stdin root
 

--- a/tempto-examples/docker/trino-server/Dockerfile
+++ b/tempto-examples/docker/trino-server/Dockerfile
@@ -1,5 +1,10 @@
 FROM ghcr.io/trinodb/testing/centos7-oj11:53
 
+# TODO: Remove when updating to newer base image
+# replace mirrorlist.centos.org and mirror.centos.org with vault.centos.org
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
 RUN yum install -y tar
 
 RUN curl -SL https://repo1.maven.org/maven2/io/trino/trino-server/356/trino-server-356.tar.gz \


### PR DESCRIPTION
Trino is only using TestNG in product tests so this change is contained and should not cause issues