### PR TITLE
Don't filter TestNG configuration methods by name/group

### DIFF
--- a/tempto-core/src/main/java/io/trino/tempto/internal/listeners/TestNameGroupNameMethodSelector.java
+++ b/tempto-core/src/main/java/io/trino/tempto/internal/listeners/TestNameGroupNameMethodSelector.java
@@ -94,6 +94,13 @@ public class TestNameGroupNameMethodSelector
     @Override
     public boolean includeMethod(IMethodSelectorContext context, ITestNGMethod method, boolean isTestMethod)
     {
+        if (!isTestMethod) {
+            // Configuration methods (e.g. @BeforeClass) must not be filtered by test name/group selection;
+            // TestNG decides whether to invoke them based on the test methods that are actually selected.
+            // They are also evaluated before the owning ITestClass is attached, so reading their metadata
+            // here (which dereferences ITestNGMethod.getTestClass()) would throw a NullPointerException.
+            return true;
+        }
         TestMetadata testMetadata = testMetadataReader.readTestMetadata(method);
         return includeBasedOnTestName(testMetadata) &&
                 !excludeBasedOnName(testMetadata) &&

--- a/tempto-core/src/main/java/io/trino/tempto/internal/listeners/TestNameGroupNameMethodSelector.java
+++ b/tempto-core/src/main/java/io/trino/tempto/internal/listeners/TestNameGroupNameMethodSelector.java
@@ -102,15 +102,28 @@ public class TestNameGroupNameMethodSelector
             return true;
         }
         TestMetadata testMetadata = testMetadataReader.readTestMetadata(method);
-        return includeBasedOnTestName(testMetadata) &&
+        return includeBasedOnNameOrGroup(testMetadata) &&
                 !excludeBasedOnName(testMetadata) &&
-                includeBasedOnGroups(testMetadata) &&
                 !excludeBasedOnGroups(testMetadata);
     }
 
-    private boolean includeBasedOnTestName(TestMetadata testMetadata)
+    private boolean includeBasedOnNameOrGroup(TestMetadata testMetadata)
     {
-        return testNamesToRun.map(strings -> indexOf(strings, testMetadata.testName::contains) != -1).orElse(true);
+        // When both test names and test groups are requested they are combined with OR: a test is included
+        // if it is explicitly named OR it belongs to a requested group. This lets a suite select a whole
+        // group plus a few additional tests by name (e.g. `-g configured_features -t SomeClass.someTest`);
+        // combining with AND would instead require a test to satisfy both filters, which for disjoint name
+        // and group sets selects nothing and ends the suite with "No tests executed". When neither filter is
+        // requested every test is included.
+        if (testNamesToRun.isEmpty() && testGroupsToRun.isEmpty()) {
+            return true;
+        }
+        return matchesRequestedName(testMetadata) || matchesRequestedGroup(testMetadata);
+    }
+
+    private boolean matchesRequestedName(TestMetadata testMetadata)
+    {
+        return testNamesToRun.map(strings -> indexOf(strings, testMetadata.testName::contains) != -1).orElse(false);
     }
 
     private boolean excludeBasedOnName(TestMetadata testMetadata)
@@ -118,9 +131,9 @@ public class TestNameGroupNameMethodSelector
         return testNamesToExclude.stream().anyMatch(exclusion -> matches(testMetadata.testName, exclusion));
     }
 
-    private boolean includeBasedOnGroups(TestMetadata testMetadata)
+    private boolean matchesRequestedGroup(TestMetadata testMetadata)
     {
-        return testGroupsToRun.map(strings -> !intersection(testMetadata.testGroups, strings).isEmpty()).orElse(true);
+        return testGroupsToRun.map(strings -> !intersection(testMetadata.testGroups, strings).isEmpty()).orElse(false);
     }
 
     private boolean excludeBasedOnGroups(TestMetadata testMetadata)

--- a/tempto-core/src/test/java/io/trino/tempto/runner/TestNameGroupNameMethodSelectorTest.java
+++ b/tempto-core/src/test/java/io/trino/tempto/runner/TestNameGroupNameMethodSelectorTest.java
@@ -108,7 +108,17 @@ public class TestNameGroupNameMethodSelectorTest
                 Arguments.of("p.q.r.abc", asList("g1", "g2"), null, asList("p.q.r.xyz"), asList("g1", "g3"), asList("g5"), true),
                 Arguments.of("p.q.r.abc", asList("g1", "g2"), null, asList("p.q.r.ab"), asList("g1", "g3"), asList("g5"), true),
                 Arguments.of("p.q.r.abc", asList("g1", "g2"), null, asList("p.q.r.abc"), asList("g1", "g3"), asList("g5"), false),
-                Arguments.of("p.q.r.abc", asList("g1", "g2"), null, asList("p.q.r"), asList("g1", "g3"), asList("g5"), false));
+                Arguments.of("p.q.r.abc", asList("g1", "g2"), null, asList("p.q.r"), asList("g1", "g3"), asList("g5"), false),
+                // When test names and test groups are both requested they are combined with OR: a test matching
+                // either filter is included. This mirrors suites that run a whole group plus a few extra tests by
+                // name (e.g. `-g configured_features -t SomeClass.someTest`), which previously selected nothing
+                // because the name and group sets are disjoint, ending the suite with "No tests executed".
+                // Named test that belongs to a non-requested group is still included by name.
+                Arguments.of("p.TestHiveCreateTable.testCreateTable", asList("storage_formats"), asList("TestHiveCreateTable.testCreateTable"), null, asList("configured_features"), null, true),
+                // Test in a requested group that is not explicitly named is still included by group.
+                Arguments.of("p.TestConfiguredFeatures.selectConfiguredConnectors", asList("configured_features"), asList("TestHiveCreateTable.testCreateTable"), null, asList("configured_features"), null, true),
+                // Matching neither the requested names nor the requested groups is excluded.
+                Arguments.of("p.TestOther.someTest", asList("other_group"), asList("TestHiveCreateTable.testCreateTable"), null, asList("configured_features"), null, false));
     }
 
     private static Optional<Set<String>> asSetOptional(List<String> strings)

--- a/tempto-core/src/test/java/io/trino/tempto/runner/TestNameGroupNameMethodSelectorTest.java
+++ b/tempto-core/src/test/java/io/trino/tempto/runner/TestNameGroupNameMethodSelectorTest.java
@@ -17,6 +17,7 @@ package io.trino.tempto.runner;
 import io.trino.tempto.internal.listeners.TestMetadata;
 import io.trino.tempto.internal.listeners.TestMetadataReader;
 import io.trino.tempto.internal.listeners.TestNameGroupNameMethodSelector;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -59,6 +60,29 @@ public class TestNameGroupNameMethodSelectorTest
 
         assertThat(testSelector.includeMethod(mock(IMethodSelectorContext.class), mock(ITestNGMethod.class), true))
                 .isEqualTo(expected);
+    }
+
+    @Test
+    public void configurationMethodsAreAlwaysIncludedWithoutReadingMetadata()
+    {
+        // Configuration methods (e.g. @BeforeClass) are evaluated by the selector before their owning
+        // ITestClass is attached, so ITestNGMethod.getTestClass() is null and reading their metadata throws
+        // a NullPointerException. They must be included regardless of test name/group filters and without
+        // touching the metadata reader. Otherwise @BeforeClass collection fails and the suite ends with
+        // "No tests executed".
+        TestMetadataReader metadataReader = mock(TestMetadataReader.class);
+        when(metadataReader.readTestMetadata(any(ITestNGMethod.class)))
+                .thenThrow(new NullPointerException("getTestClass() is null for configuration methods"));
+        TestNameGroupNameMethodSelector testSelector = new TestNameGroupNameMethodSelector(
+                asSetOptional(asList("someTestThatDoesNotMatch")),
+                asSet(null),
+                asSetOptional(asList("groupThatDoesNotMatch")),
+                asSet(null),
+                metadataReader);
+
+        boolean isTestMethod = false;
+        assertThat(testSelector.includeMethod(mock(IMethodSelectorContext.class), mock(ITestNGMethod.class), isTestMethod))
+                .isTrue();
     }
 
     static Stream<Arguments> testSelectorMatchData()


### PR DESCRIPTION
TestNG 7.8.0 runs config methods (@BeforeClass) through the method selector before their ITestClass is attached, so getTestClass() is null and reading metadata NPE'd, ending the suite with "No tests executed".

Return true for non-test methods in TestNameGroupNameMethodSelector so config methods are never filtered.